### PR TITLE
fix the bug in image.py

### DIFF
--- a/python/radmc3dPy/radmc3dPy/image.py
+++ b/python/radmc3dPy/radmc3dPy/image.py
@@ -385,7 +385,7 @@ class radmc3dImage(object):
 
             else:
                 for inu in range(self.nfreq):
-                    data[inu, 0, :, :] = self.image[:, :, inu] * conv
+                    data[0, inu, :, :] = self.image[:, :, inu] * conv
         else:
             data = np.zeros([self.nfreq, self.nx, self.ny], dtype=float)
             if self.stokes:


### PR DESCRIPTION
The function will yield the index error when saving the fits file with casa option enabled. It's because the index `inu`  was put in the wrong place. In line 388, data[inu, 0,  :, :] should be revised to data[0, inu, :, :].